### PR TITLE
Fix client scheduler shutdown

### DIFF
--- a/common/src/main/java/de/the_build_craft/maplink/common/AbstractModInitializer.java
+++ b/common/src/main/java/de/the_build_craft/maplink/common/AbstractModInitializer.java
@@ -52,16 +52,18 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static de.the_build_craft.maplink.common.CommonModConfig.*;
 
 /**
- * Base for all mod loader initializers 
+ * Base for all mod loader initializers
  * and handles most setup.
  *
  * @author James Seibel
  * @author Leander Knüttel
- * @version 11.08.2026
+ * @author Maggesss
+ * @version 04.09.2026
  */
 public abstract class AbstractModInitializer
 {
@@ -95,21 +97,28 @@ public abstract class AbstractModInitializer
     public static boolean xaeroWorldMapInstalled = false;
 	public static boolean overwriteCurrentDimension = false;
 
-	private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
-	
+    private static final Object schedulerLock = new Object();
+    private static final AtomicInteger schedulerThreadId = new AtomicInteger();
+    private static final ScheduledExecutorService scheduler =
+            Executors.newScheduledThreadPool(2, runnable -> {
+                Thread thread = new Thread(runnable, "MapLink-Scheduler-" + schedulerThreadId.getAndIncrement());
+                thread.setDaemon(true);
+                return thread;
+            });
+
 	//==================//
 	// abstract methods //
 	//==================//
-	
+
 	protected abstract void createInitialBindings();
 	protected abstract IEventProxy createClientProxy();
 	protected abstract IEventProxy createServerProxy(boolean isDedicated);
 	protected abstract void initializeModCompat();
-	
+
 	//===================//
 	// initialize events //
 	//===================//
-	
+
 	public void onInitializeClient()
 	{
 		LOGGER.info("Initializing " + MOD_NAME);
@@ -140,11 +149,11 @@ public abstract class AbstractModInitializer
 
 		LOGGER.info(MOD_NAME + " Initialized");
 	}
-	
+
 	public void onInitializeServer()
 	{
 		LOGGER.info("Initializing " + MOD_NAME);
-		
+
 		this.startup();//<-- common mod init in here
 		this.printModInfo();
 
@@ -154,7 +163,7 @@ public abstract class AbstractModInitializer
 
 		LOGGER.info(MOD_NAME + " Initialized");
 	}
-	
+
 	//===========================//
 	// inner initializer methods //
 	//===========================//
@@ -168,7 +177,7 @@ public abstract class AbstractModInitializer
 		this.createInitialBindings();
 		//do common mod init here
 	}
-	
+
 	private void printModInfo()
 	{
 		LOGGER.info(MOD_NAME + ", Version: " + VERSION);
@@ -275,6 +284,7 @@ public abstract class AbstractModInitializer
                             Utils.sendErrorToClientChat("Currently only available for Bluemap. This will be expanded in future updates ☺");
                             return 0;
                         }
+
                         int chunksX = IntegerArgumentType.getInteger(context, "chunksX") + 2;
                         int chunksZ = IntegerArgumentType.getInteger(context, "chunksZ") + 2;
                         BlockPos center = parseClientPos(context.getArgument("center", Coordinates.class));
@@ -300,6 +310,7 @@ public abstract class AbstractModInitializer
                                     Utils.sendErrorToClientChat("Currently only available for Bluemap. This will be expanded in future updates ☺");
                                     return 0;
                                 }
+
                                 int chunksX = IntegerArgumentType.getInteger(context, "chunksX") + 2;
                                 int chunksZ = IntegerArgumentType.getInteger(context, "chunksZ") + 2;
                                 BlockPos center = parseClientPos(context.getArgument("center", Coordinates.class));
@@ -347,9 +358,11 @@ public abstract class AbstractModInitializer
 	private static LiteralArgumentBuilder<CommandSourceStack> literal(String string) {
 		return LiteralArgumentBuilder.literal(string);
 	}
+
 	private static <T> RequiredArgumentBuilder<CommandSourceStack, T> argument(String name, ArgumentType<T> type) {
 		return RequiredArgumentBuilder.argument(name, type);
 	}
+
     private static BlockPos parseClientPos(Coordinates coordinates) {
         WorldCoordinates worldCoordinates = (WorldCoordinates) coordinates;
         BlockPos playerPos = Minecraft.getInstance().player.blockPosition();
@@ -368,10 +381,12 @@ public abstract class AbstractModInitializer
 	public static void setUpdateDelay(int ms) {
 		int maxUpdateDelay = Math.min(4000, Math.max(config.general.maxUpdateDelay, 1000));
 		ms = Math.min(maxUpdateDelay, Math.max(ms, 1000));
-		if (ms == timerDelay || scheduledSlowUpdateTask == null) return;
-		timerDelay = ms;
-		scheduledSlowUpdateTask.cancel(true);
-		scheduledSlowUpdateTask = scheduler.scheduleAtFixedRate(slowUpdateTask::run, 0, timerDelay, TimeUnit.MILLISECONDS);
+		synchronized (schedulerLock) {
+			if (ms == timerDelay || scheduledSlowUpdateTask == null) return;
+			timerDelay = ms;
+			scheduledSlowUpdateTask.cancel(true);
+			scheduledSlowUpdateTask = scheduler.scheduleAtFixedRate(slowUpdateTask::run, 0, timerDelay, TimeUnit.MILLISECONDS);
+		}
 		LOGGER.info("Remote update delay has been set to " + ms + " ms");
 		if (config.general.debugMode) Utils.sendToClientChat("Remote update delay has been set to " + ms + " ms");
 	}
@@ -455,11 +470,11 @@ public abstract class AbstractModInitializer
 			return null;
 		}
 	}
-	
+
 	//================//
 	// helper classes //
 	//================//
-	
+
 	public interface IEventProxy
 	{
 		void registerEvents();


### PR DESCRIPTION
## Summary

This fixes a client shutdown issue where Map Link's scheduled update executor can keep the JVM alive after Minecraft has already finished shutting down.

Since the executor uses non-daemon worker threads and was never explicitly stopped, Minecraft can eventually trigger the client shutdown watchdog.

## Fix

- cancel the fast and slow scheduled update tasks during client shutdown
- shut down the shared scheduler with `shutdownNow()`
- register the appropriate shutdown event for Fabric, NeoForge and Forge

[edit]
- use daemon threads so the scheduler cannot keep the JVM alive
- synchronize rescheduling and shutdown to prevent race conditions

## Reproduction

Originally reproduced with:

- Minecraft 26.2
- Map Link 4.5.0
- Fabric Loader 0.19.3
- Fabric API 0.157.0+26.2
- Java 25.0.1
- CachyOS Linux
- ATLauncher 3.4.41.2
- Fabulously Optimized 14.0.0-beta.4 with a few additional mods

Minecraft itself reaches the normal shutdown point:

```text
[Render thread/INFO]: Stopping!
```

but the process stays alive until the shutdown watchdog kicks in:

```text
Description: Client shutdown from post-main
java.lang.Error: Watchdog (Client shutdown from post-main)
```

The thread dump still shows the two `ScheduledThreadPoolExecutor` workers used by Map Link.

## Testing

- Ran the project's `buildAll` script successfully
- Fabric and NeoForge builds completed successfully for all configured targets
- Manually tested the Fabric 26.2 build: Minecraft now exits normally without triggering the shutdown watchdog
- Forge isn't currently part of the released/build targets, the same shutdown handling was added there as well, but I didnt build or test it